### PR TITLE
Remove class 'et_social_inline_bottom'

### DIFF
--- a/monarch-sharing-shortcode.php
+++ b/monarch-sharing-shortcode.php
@@ -23,12 +23,12 @@ function monarch_sharing_shortcode($atts) {
 		'monarch_share'
 	);
   
-  return generate_inline_icons('et_social_inline_bottom', $atts['url'], $atts['center']);
+  return generate_inline_icons($atts['url'], $atts['center']);
 }
 add_shortcode('monarch_share', 'MSS\\monarch_sharing_shortcode');
 
 // copied from monarch.php and edited to allow manually specifying URL
-function generate_inline_icons($class = 'et_social_inline_bottom', $url = '', $center = false) {
+function generate_inline_icons($url = '', $center = false) {
   $monarch = $GLOBALS['et_monarch'];
   $monarch_options = $monarch->monarch_options;
 
@@ -39,8 +39,8 @@ function generate_inline_icons($class = 'et_social_inline_bottom', $url = '', $c
   $display_all_button = isset( $monarch_options[ 'sharing_inline_display_all' ] ) ? $monarch_options[ 'sharing_inline_display_all' ] : false;
 
   $inline_content = sprintf(
-    '<div class="et_social_inline%10$s %12$s %14$s">
-      <div class="et_social_networks et_social_%2$s et_social_%3$s et_social_%4$s et_social_%5$s et_social_no_animation%6$s%7$s%9$s%11$s%13$s">
+    '<div class="et_social_inline%10$s %13$s">
+      <div class="et_social_networks et_social_%2$s et_social_%3$s et_social_%4$s et_social_%5$s et_social_no_animation%6$s%7$s%9$s%11$s%12$s">
         %8$s
         %1$s
       </div>
@@ -67,8 +67,7 @@ function generate_inline_icons($class = 'et_social_inline_bottom', $url = '', $c
     true == $monarch_options[ 'sharing_inline_spacing' ] ? ' et_social_nospace' : '',
     true == $monarch_options[ 'sharing_inline_mobile' ] ? ' et_social_mobile_off' : ' et_social_mobile_on', //#10
     true == $monarch_options[ 'sharing_inline_network_names' ] ? ' et_social_withnetworknames' : '',
-    esc_attr( $class ),
-    esc_attr( sprintf( ' et_social_outer_%1$s', $monarch_options[ 'sharing_inline_outer_color' ] ) ), //#13
+    esc_attr( sprintf( ' et_social_outer_%1$s', $monarch_options[ 'sharing_inline_outer_color' ] ) ), //#12
     true == $center ? 'mss-center' : ''
   );
   if ($center) {


### PR DESCRIPTION
**Issue:**
 If using a DIVI custom Layout the shortcode doesn't work properly. It goes automatically under content. 

**Cause:**
On the official plugin on file called `/monarch/js/custom.js`, `lines 507 -> 529`, the plugin search the class `et_social_inline_bottom` and checks if the `body` element has the class `et_pb_pagebuilder_layout` and if that is the case it takes the social icons generated by the shortcode and puts under the content.

These are the lines:
```
// Move inline icons into appropriate sections in Divi theme
		if( $( '.et_social_inline' ).length ) {
			if ( $( 'body' ).hasClass( 'et_pb_pagebuilder_layout' ) ) {
				var top_inline = $( '.et_social_inline_top' ),
					bottom_inline = $( '.et_social_inline_bottom' ),
					divi_container = '<div class="et_pb_row"><div class="et_pb_column et_pb_column_4_4"></div></div>';

				if ($('.et-l--post').first().length > 0) {
					var $sections = $('.et-l--post .et_pb_section').not('.et_pb_fullwidth_section');
				} else {
					// Backwards compatibility before .et-l was introduced.
					var $sections = $('.et_pb_section:not(.et-l .et_pb_section)').not('.et_pb_fullwidth_section');
				}

				if ($sections.length > 0 && top_inline.length) {
					$sections.first().prepend(divi_container).find('.et_pb_row').first().find('.et_pb_column').append(top_inline);
				}

				if ($sections.length > 0 && bottom_inline.length) {
					$sections.last().append(divi_container).find('.et_pb_row').last().find('.et_pb_column').append(bottom_inline);
				}
			}
		}
```

**A possible solution:**
Since the class `et_social_inline_bottom` cause this and the class doesn't contain too much css code a possible solution is just to remove it.